### PR TITLE
サイズ指定を厳格化

### DIFF
--- a/src/css/crsearch.scss
+++ b/src/css/crsearch.scss
@@ -15,9 +15,9 @@ $cs-bd-result: $theme-color;
 $cs-bg-result-hover: rgb(240, 246, 255);
 $cs-bd-result-sep: #AAA;
 
-$control-font-size: 1.1rem;
+$control-font-size: 1.1em;
 $control-border: 2px;
-$search-input-height: 1.8rem;
+$search-input-height: 1.8em;
 
 
 .crsearch {
@@ -29,7 +29,7 @@ $search-input-height: 1.8rem;
 
     > .input {
       min-width: 300px;
-      padding: 0 2.4rem 0 .4rem;
+      padding: 0 2.4em 0 .4em;
       border: $control-border solid #DDD;
 
       font-size: $control-font-size;
@@ -41,7 +41,7 @@ $search-input-height: 1.8rem;
       top: $control-border;
       right: $control-border;
       border-left: 1px dotted #DDD;
-      padding: 0 .5rem;
+      padding: 0 .5em;
       background: #FFF;
       color: $theme-color;
       cursor: pointer;
@@ -64,7 +64,7 @@ $search-input-height: 1.8rem;
     min-width: 340px;
     z-index: 9999;
     background: $cs-bg-result;
-    min-height: 2rem;
+    min-height: 2em;
     left: 0;
     box-shadow: 1px 1px 1px rgba(0, 0, 0, 0.2);
 
@@ -83,7 +83,7 @@ $search-input-height: 1.8rem;
 
     > .help-content {
       display: none;
-      padding: 1rem .5rem .5rem .5rem;
+      padding: 1em .5em .5em .5em;
 
       > .message {
         color: darken($theme-color, 10%);
@@ -92,8 +92,8 @@ $search-input-height: 1.8rem;
         line-height: 1.5;
 
         &:not(:empty) {
-          padding: .25rem .5rem;
-          margin-bottom: 1rem;
+          padding: .25em .5em;
+          margin-bottom: 1em;
           border-left: 4px solid lighten($theme-color, 40%);
         }
       }
@@ -104,13 +104,13 @@ $search-input-height: 1.8rem;
           padding: 0;
 
           &:not(:last-child) {
-            margin-bottom: 1rem;
+            margin-bottom: 1em;
           }
 
           h3 {
             padding: 0;
             margin: 0;
-            font-size: 1.05rem;
+            font-size: 1.05em;
             font-weight: bold;
             font-style: oblique;
             font-family: sans-serif;
@@ -118,8 +118,8 @@ $search-input-height: 1.8rem;
           }
 
           .query {
-            margin: .3rem 0 0 .75rem;
-            font-size: 1.05rem;
+            margin: .3em 0 0 .75em;
+            font-size: 1.05em;
             color: #6A6A6A;
 
             .input:before {
@@ -141,11 +141,11 @@ $search-input-height: 1.8rem;
       font-family: monospace;
       font-style: oblique;
       font-weight: normal;
-      font-size: 0.6rem;
+      font-size: 0.6em;
       text-align: right;
       background: #F0F0F0;
       margin: 0;
-      padding: .2rem .4rem .25rem .4rem;
+      padding: .2em .4em .25em .4em;
 
       a {
         color: #888;
@@ -192,20 +192,20 @@ $search-input-height: 1.8rem;
       cursor: default;
       display: flex;
       justify-content: flex-end;
-      padding: .2rem .4rem;
+      padding: .2em .4em;
 
       .db-name, .extra {
         display: inline-block;
       }
 
       .db-name {
-        padding: 0 0 0 .5rem;
-        font-size: .9rem;
+        padding: 0 0 0 .5em;
+        font-size: .9em;
         font-weight: bold;
         text-decoration: none;
       }
       .extra {
-        font-size: .8rem;
+        font-size: .8em;
         color: #444;
         margin-right: auto;
 
@@ -244,7 +244,7 @@ $search-input-height: 1.8rem;
         display: flex;
         align-items: flex-start;
 
-        padding: .4rem;
+        padding: .4em;
         line-height: 1.4;
         font-family: monospace;
         text-decoration: none;
@@ -262,17 +262,17 @@ $search-input-height: 1.8rem;
           display: inline-block;
           width: 5em;
           font-family: monospace;
-          font-size: .8rem;
+          font-size: .8em;
           text-align: center;
 
-          padding: .05rem .2rem;
-          margin: 0 .25rem 0 0;
+          padding: .05em .2em;
+          margin: 0 .5em 0 0;
         }
 
         > .content {
           display: inline-block;
           flex: 1;
-          font-size: 1rem;
+          font-size: 1em;
         }
       } // a
 
@@ -280,7 +280,7 @@ $search-input-height: 1.8rem;
         > a:before {
           content: 'Google';
           color: $badge-google-fallback;
-          // font-size: .9rem;
+          // font-size: .9em;
           margin-top: 0;
           background: none;
           font-weight: bold;
@@ -303,8 +303,8 @@ $search-input-height: 1.8rem;
             }
 
             font-size: .9em;
-            margin: 0 0 0 .2rem;
-            padding: .05rem .25rem;
+            margin: 0 0 0 .2em;
+            padding: .05em .25em;
             color: #444;
             background: #DDD;
           }
@@ -320,7 +320,7 @@ $search-input-height: 1.8rem;
 
       &.cpp-namespace {
         > a:before {
-          font-size: .7rem;
+          font-size: .7em;
           content: 'namespace';
           background: $badge-cpp-namespace;
           color: #EEE;
@@ -404,7 +404,7 @@ $search-input-height: 1.8rem;
         }
         > a > .content {
           font-family: serif;
-          font-size: .8rem;
+          font-size: .8em;
           text-decoration: underline;
         }
       }

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -96,12 +96,7 @@ module.exports = {
               loader: 'file-loader',
               options: {
                 name: '[name].[ext]?[hash]',
-                publicPath() {
-                  if (process.env.NODE_ENV === 'production') {
-                    return '/static/crsearch/';
-                  }
-                  return '/';
-                },
+                publicPath: '../',
                 outputPath: 'fonts/',
               },
             },


### PR DESCRIPTION
以前→remでドキュメントルートからの相対指定
このPR→emで直上親要素からの相対指定

`.crsearch` の `font-size` に配慮するようにしたので、本番でも開発でもこの修正で正しく表示されると思います。