### PR TITLE
候補を矢印キーで選択した時にページがスクロールしてしまう問題を修正

### DIFF
--- a/src/js/crsearch.js
+++ b/src/js/crsearch.js
@@ -283,8 +283,14 @@ export default class CRSearch {
 
     let box = $(sel)
     box.attr('data-crsearch-id', id)
-    Mousetrap.bind('up', this.selectChange.bind(this, true, box))
-    Mousetrap.bind('down', this.selectChange.bind(this, false, box))
+    Mousetrap.bind('up', e => {
+      e.preventDefault()
+      this.selectChange(true, box)
+    })
+    Mousetrap.bind('down', e => {
+      e.preventDefault()
+      this.selectChange(false, box)
+    })
 
     this.last_input[id] = ''
 


### PR DESCRIPTION
候補をカーソルキーで選択する時，ブラウザのデフォルトの挙動でページがスクロールしてしまう問題を修正しました．

![修正対象](https://user-images.githubusercontent.com/823277/31923441-77b76fa0-b8b5-11e7-9737-ce011317cb49.gif)
