### PR TITLE
fix: support IE11

### DIFF
--- a/js/crsearch/database.js
+++ b/js/crsearch/database.js
@@ -9,6 +9,7 @@ import URL from 'url-parse'
 
 import * as Query from './query'
 
+const arrayEntries = require('core-js/library/fn/array/entries')
 
 class Database {
   constructor(log, json) {
@@ -33,7 +34,7 @@ class Database {
 
     this.log.debug('[P1] initializing all IndexID...')
     let fallback_001_used = false
-    for (const [s_key, id] of json.ids.entries()) {
+    for (const [s_key, id] of arrayEntries(json.ids)) {
       const iid = new IndexID(this.log, s_key, id)
 
       // legacy fallback
@@ -61,7 +62,7 @@ class Database {
     }
 
     this.log.debug('[P1] initializing all Namespace...')
-    for (const [s_key, j_ns] of json.namespaces.entries()) {
+    for (const [s_key, j_ns] of arrayEntries(json.namespaces)) {
       const ns = new Namespace(this.log, s_key, j_ns, this.ids, this.make_url.bind(this))
       this.log.debug(`got Namespace: '${ns.pretty_name()}'`, ns)
       this.namespaces.push(ns)

--- a/js/crsearch/database.js
+++ b/js/crsearch/database.js
@@ -10,6 +10,7 @@ import URL from 'url-parse'
 import * as Query from './query'
 
 const arrayEntries = require('core-js/library/fn/array/entries')
+const arrayIncludes = require("core-js/library/fn/array/includes")
 
 class Database {
   constructor(log, json) {
@@ -111,7 +112,7 @@ class Database {
 
           this.all_classes.get(cand).members.add(idx)
 
-        } else if ([IType.article, IType.meta].includes(idx.id.type)) {
+        } else if (arrayIncludes([IType.article, IType.meta], idx.id.type)) {
           if (idx.isRootArticle()) {
             this.root_articles.set(
               idx.ns,

--- a/js/crsearch/dom.js
+++ b/js/crsearch/dom.js
@@ -1,3 +1,5 @@
+const arrayIncludes = require("core-js/library/fn/array/includes")
+
 class DOM {
   static defaultOptions = {
     links: {
@@ -34,7 +36,7 @@ class DOM {
         }
       }
 
-      if (['deprecated_in_latest', 'removed_in_latest', 'added_in_latest'].includes(attr)) {
+      if (arrayIncludes(['deprecated_in_latest', 'removed_in_latest', 'added_in_latest'], attr)) {
         li.addClass('latest-spec')
       }
     }

--- a/js/crsearch/index-id.js
+++ b/js/crsearch/index-id.js
@@ -1,5 +1,7 @@
 import {IndexType as IType} from './index-type'
 
+const arrayIncludes = require("core-js/library/fn/array/includes")
+
 class IndexID {
   static VERBATIM_TRS = new Map([
     ['コンストラクタ', {to: '(constructor)', only: IType.mem_fun}],
@@ -31,7 +33,7 @@ class IndexID {
   }
 
   static isClassy(type) {
-    return [IType.class, IType.function, IType.mem_fun, IType.enum, IType.variable, IType.type_alias].includes(type)
+    return arrayIncludes([IType.class, IType.function, IType.mem_fun, IType.enum, IType.variable, IType.type_alias], type)
   }
 
   constructor(log, s_key, json) {
@@ -69,17 +71,17 @@ class IndexID {
     this.keys = keys.map((k) => k.normalize('NFKC'))
 
     for (const [k, v] of IndexID.VERBATIM_TRS) {
-      if (v.only && ![].concat(v.only).includes(this.type)) {
+      if (v.only && !arrayIncludes([].concat(v.only), this.type)) {
         continue
       }
 
-      if (this.keys[this.keys.length - 1].includes(k)) {
+      if (arrayIncludes(this.keys[this.keys.length - 1], k)) {
         this.keys[this.keys.length - 1] = this.keys[this.keys.length - 1].replace(k, `${v.to}`)
 
         if (v.type) {
           this.type = v.type
 
-          if ([IType.class, IType.mem_fun].includes(this.type) && this.keys[0] !== 'std') {
+          if (arrayIncludes([IType.class, IType.mem_fun], this.type) && this.keys[0] !== 'std') {
             this.keys.unshift('std')
           }
         }

--- a/js/crsearch/index-id.js
+++ b/js/crsearch/index-id.js
@@ -68,7 +68,7 @@ class IndexID {
       keys = ns.concat(keys)
     }
     this.cpp_namespace = keys
-    this.keys = keys.map((k) => k.normalize('NFKC'))
+    this.keys = (typeof String.prototype.normalize === 'function') ? keys.map((k) => k.normalize('NFKC')) : keys
 
     for (const [k, v] of IndexID.VERBATIM_TRS) {
       if (v.only && !arrayIncludes([].concat(v.only), this.type)) {

--- a/js/crsearch/index.js
+++ b/js/crsearch/index.js
@@ -3,6 +3,7 @@ import {IndexID} from './index-id'
 
 import {DOM} from './dom'
 
+const arrayIncludes = require("core-js/library/fn/array/includes")
 
 class Index {
   constructor(log, cpp_version, id, json, make_url) {
@@ -30,7 +31,7 @@ class Index {
   }
 
   isRootArticle() {
-    return this.page_id[0].length === 0 /* && [IType.meta, IType.article].includes(this.id.type) */
+    return this.page_id[0].length === 0 /* && arrayIncludes([IType.meta, IType.article], this.id.type) */
   }
 
   isParent() {
@@ -80,11 +81,11 @@ class Index {
   }
 
   static ambgMatch(idx, q) {
-    if ([IType.article, IType.meta].includes(idx.id.type)) {
-      return idx.id_cache.toLowerCase().includes(q.toLowerCase())
+    if (arrayIncludes([IType.article, IType.meta], idx.id.type)) {
+      return arrayIncludes(idx.id_cache.toLowerCase(), q.toLowerCase())
     }
 
-    return idx.id_cache.includes(q)
+    return arrayIncludes(idx.id_cache, q)
   }
 }
 

--- a/js/crsearch/query.js
+++ b/js/crsearch/query.js
@@ -9,7 +9,7 @@ class Query {
   constructor(log, text) {
     this.log = log.makeContext('Query')
     this.original_text = text
-    this.frags = text.normalize('NFKC').split(/\s+/).filter(Boolean)
+    this.frags = ((typeof String.prototype.normalize === 'function') ? text.normalize('NFKC') : text).split(/\s+/).filter(Boolean)
 
     this.filters = new Set
 

--- a/package.json
+++ b/package.json
@@ -39,10 +39,10 @@
     "cssnano": "^4.0.0-rc.2",
     "expose-loader": "^0.7.3",
     "extract-text-webpack-plugin": "^3.0.2",
-    "file-loader": "^0.11.2",
+    "file-loader": "^1.1.5",
     "handlebars": "^4.0.11",
     "handlebars-loader": "^1.6.0",
-    "html-webpack-include-assets-plugin": "0.0.7",
+    "html-webpack-include-assets-plugin": "1.0.2",
     "html-webpack-plugin": "^2.30.1",
     "mousetrap": "^1.6.1",
     "node-sass": "^4.6.0",
@@ -51,7 +51,7 @@
     "precss": "^2.0.0",
     "raw-loader": "^0.5.1",
     "sass-loader": "^6.0.6",
-    "style-loader": "^0.18.2",
+    "style-loader": "^0.19.0",
     "webpack": "^3.8.1",
     "webpack-dev-server": "^2.9.4",
     "webpack-merge": "^4.1.1"
@@ -61,7 +61,7 @@
     "font-awesome": "^4.7.0",
     "jquery": "^3.2.1",
     "marked": "^0.3.6",
-    "nagato": "^1.8.2",
+    "nagato": "^1.8.3",
     "url-parse": "^1.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
   },
   "dependencies": {
     "babel-runtime": "^6.26.0",
+    "core-js": "^2.5.1",
     "font-awesome": "^4.7.0",
     "jquery": "^3.2.1",
     "marked": "^0.3.6",


### PR DESCRIPTION
https://github.com/cpprefjp/site/issues/477
より。
IE11で条件付きで動かすことに成功した。

ついでなので https://github.com/cpprefjp/kunai/pull/37 に追従して

file-loader: 0.11.2 -> 1.1.5
html-webpack-include-assets-plugin: 0.0.7 -> 1.0.2
style-loader: 0.18.2 -> 0.19.0

nagato: 1.8.2 -> 1.8.3

に依存バージョンを上げています。

ref:
- https://github.com/cpprefjp/kunai/pull/53