### PR TITLE
サイドバーや検索がローカルで正しく動作しない問題を修正

### DIFF
--- a/js/crsearch/crsearch.js
+++ b/js/crsearch/crsearch.js
@@ -92,6 +92,7 @@ class CRSearch {
 
         $.ajax({
           url: url,
+          dataType: "json",
 
           success: async (data) => {
             this.log.info('fetched')


### PR DESCRIPTION
ローカルで動作させる時に、site_generator では python の SimpleHTTPServer
を使用しているが、crsearch.json を SimpleHTTPServer に取得に行った際、
デフォルトの状態では content-type を application/json ではなく
application/octet-stream で返してしまうため、jQuery の $.ajax がコール
バックに json ではなく文字列を渡し、後続の処理でエラーが発生していた。
そこで、content-type にかかわらず json として解釈するように修正した。

なお、サイドバーや検索をローカルで正しく動作させるためには、本修正の他に
kunai と site_generator の修正も必要。