### PR TITLE
CPO を検索できない問題を修正

### DIFF
--- a/js/crsearch/index-type.js
+++ b/js/crsearch/index-type.js
@@ -28,7 +28,7 @@ const IndexType = {
   },
 
   isClassy(type) {
-    return [this.class, this.function, this.mem_fun, this.enum, this.variable, this.type_alias, this.concept, this.namespace].includes(type)
+    return [this.class, this.function, this.mem_fun, this.enum, this.variable, this.type_alias, this.concept, this.namespace, this.cpo].includes(type)
   },
 }
 


### PR DESCRIPTION
cpprefjp で、 CPO が検索結果に出なかったり、サイドバーの CPO の表示に名前空間が含まれなかったりする問題を修正しました。

![cpprefjp_cpoに関するバグ](https://user-images.githubusercontent.com/61970673/188265034-35ff2c1a-44cb-441f-8268-52542dde721b.png)
